### PR TITLE
Unit testing, and minor RKR call change

### DIFF
--- a/cse/cse_setup.py
+++ b/cse/cse_setup.py
@@ -126,7 +126,7 @@ def potential_energy_curves(pecfs=None, R=None, dirpath='./', suffix='',
     Rin = []
     Vin = []
     for i,fn in enumerate(pecfs):
-        if isinstance(fn, (np.str)):
+        if isinstance(fn, (str)):
             radialcoord, potential = np.loadtxt(dirpath+'/'+fn+suffix,
                                                 unpack=True)
             fn = fn.split('/')[-1].upper()

--- a/cse/tests/test_cse.py
+++ b/cse/tests/test_cse.py
@@ -1,0 +1,45 @@
+import numpy as np
+import cse
+import numpy.testing as npt
+
+def test_O2X():
+    X = cse.Cse('O2', dirpath='../../examples/potentials', suffix='.dat',
+                VT=['X3S-1'])
+
+    npt.assert_equal(X.AM, [(1, 1, 0, 1, 0)])
+    npt.assert_almost_equal(X.μ, 1.328e-26)
+
+    X.solve(800)
+
+    npt.assert_almost_equal(X.cm, 787.40, decimal=2)
+    npt.assert_almost_equal(X.Bv, 1.438, decimal=3)
+    npt.assert_almost_equal(X.Dv, 4.84e-6, decimal=6)
+
+def test_transition():
+    X = cse.Cse('O2', dirpath='../../examples/potentials', suffix='.dat',
+                VT=['X3S-1'], en=800)
+    B = cse.Cse('O2', dirpath='../../examples/potentials', suffix='.dat',
+                VT=['B3S-1'])
+
+    BX = cse.Transition(B, X, dipolemoment=[1])
+    BX.calculate_xs(transition_energy=[51968,])
+
+    npt.assert_almost_equal(BX.wavenumber, 51968.39, decimal=2)
+
+def test_coupled_channel():
+    X = cse.Cse('O2', dirpath='../../examples/potentials', suffix='.dat',
+                VT=['X3S-1'], en=800)
+    BE = cse.Cse('O2', dirpath='../../examples/potentials', suffix='.dat',
+                 VT=['B3S-1', 'E3S-1'], coup=[4000])
+    BEX = cse.Transition(BE, X, dipolemoment=[1, 0])
+
+    # O₂ Longest-band
+    BEX.calculate_xs(transition_energy=np.arange(81300, 81390, 4))
+
+    npt.assert_almost_equal(BEX.wavenumber[BEX.xs[:, 0].argmax()], 81344,
+                            decimal=0)
+
+if __name__ == '__main__':
+    test_O2X()
+    test_transition()
+    test_coupled_channel()

--- a/cse/tools/RKR.py
+++ b/cse/tools/RKR.py
@@ -165,7 +165,7 @@ def Morse(x, β, Re, De, Voo):
     return De*(1 - np.exp(-β*(x-Re)))**2 + Te
 
 # analytical functions
-def inner_limb_Morse(R, P, RTP, PTP, Re, De, Voo, verbose=True):
+def inner_limb_Morse(R, P, RTP, PTP, Re, De, Voo, inner=None, verbose=True):
     # V(r) = De[1 - exp(-β(R-Re))]² + Te
     Te = Voo - De
 
@@ -174,7 +174,8 @@ def inner_limb_Morse(R, P, RTP, PTP, Re, De, Voo, verbose=True):
     β = ln0/(Re - RTP[0])
 
     # fit Morse to inner turning points - adjusting β, Re, De; fixed Voo
-    inner = len(PTP) // 2
+    if not inner:
+        inner = len(PTP) // 2
     popt, pcov = curve_fit(lambda x, β, Re, De: Morse(x, β, Re, De, Voo),
                            RTP[:inner], PTP[:inner], p0=[β, Re, De])
     err = np.sqrt(np.diag(pcov))


### PR DESCRIPTION
Additional unit testing to verify coupled-channel code.

Can now set RKR inner-limb extension join `index`.