### PR TITLE
Mx

### DIFF
--- a/cse/cse.py
+++ b/cse/cse.py
@@ -51,7 +51,7 @@ class Cse():
         eigenvalue energy in eV
 
     results : dict
-        single state calculation results  {vib: (energy, Bv, Dv, Jrot)} in cm-1
+        single state calculation results {vib: (energy, Bv, Dv, Jrot)} in cm-1
         (see also class representation)
 
     molecule: str
@@ -81,16 +81,12 @@ class Cse():
     """
 
 
-    def __init__(self, μ=None, R=None, VT=None, coup=None, eigenbound=None,
-                 en=None, rot=0, mx=None,
-                 dirpath='./', suffix='', frac_Omega=False):
+    def __init__(self, μ=None, R=None, VT=None, coup=None, en=None, rot=0,
+                 mx=None, dirpath='./', suffix='', frac_Omega=False):
 
         self._evcm = 8065.541
         self.set_μ(μ=μ)
         self.rot = rot
-
-        if eigenbound is None:
-            self.eigenbound = 500/self._evcm  # eV
 
         if R is not None:
             # PEC array provided directly
@@ -112,7 +108,7 @@ class Cse():
         if np.any(zeros):
             self.R[zeros] = 1.0e-16
 
-        self.results = {} # store results for single bound channel
+        self.results = {} # store results of bound channels
         if en is not None:
             self.solve(en, self.rot, mx=mx)
 
@@ -123,7 +119,7 @@ class Cse():
         self.VT = cse_setup.coupling_function(self.R, self.VT, self.μ,
                                               self.pecfs, coup=coup)
 
-    def solve(self, en, rot=None, mx=None, eigenbound=None):
+    def solve(self, en, rot=None, mx=None):
         """ solve the Schrodinger equation for the (coupled) potential(s).
 
         Parameters
@@ -132,21 +128,13 @@ class Cse():
             (initial) solution energy
         rot : int
             total angular momentum (excluding nuclear)
-        eigenbound : float
-            bound-eigenvalue limits en+-eigenbound - same units as en
-            This helps scipy.optimize.least_squares() from straying 
         """
 
         if en > 20:
             en /= self._evcm   # convert to eV energy unit
-            if eigenbound is not None:
-                eigenbound /= self._evcm
 
         if rot is not None:
             self.rot = rot   # in case called separately
-
-        if eigenbound is not None:
-            self.eigenbound = eigenbound
 
         johnson.solveCSE(self, en, mx=mx)
 
@@ -167,7 +155,7 @@ class Cse():
 
         wfx = self.wavefunction[self.energy > V]  # inside well
 
-        vib = (wfx[1:]*wfx[:-1] < 0).sum()
+        vib = (wfx[1:]*wfx[:-1] < 0).sum(dtype=int)
 
         self.vib = vib
         return vib
@@ -195,19 +183,17 @@ class Cse():
             attribute .results = {vib: (energy, Bv, Dv, rot)}
 
         """
-        V = np.transpose(self.VT[0][0])
+        V = self.VT[0][0]
         Te = V.min()*self._evcm
         Voo = V[-1]*self._evcm
 
         if ntrial is None:
-            ntrial = int((Voo - Te)/2000)
-            if ntrial < 5:
-                ntrial = 5
+            ntrial = max(int((Voo - Te)/2000), 5)
 
         for en in np.linspace(Te+100, Voo-10, ntrial):
             self.solve(en)
             if vmax is not None and self.vib > vmax and len(self.results) > 3:
-                break  # don't waste time
+                break  # don't waste time evaluating energies above vmax
 
         maxv = max(list(self.results.keys()))
         if vmax is None:
@@ -215,13 +201,15 @@ class Cse():
         else:
             vmax = min(maxv, vmax)  # no extrapolation
 
-        # interpolate calculation
+        # interpolate calculated values
         v = np.arange(vmax+1)
 
-        vib = sorted(self.results.keys())
-        actual = [self.results[vi][0] for vi in vib]
-        Bv = [self.results[vi][1] for vi in vib]
-        Dv = [self.results[vi][2] for vi in vib]
+        vib, actual, Bv, Dv = ([] for _ in range(4))
+        for vi, (Gi, Bi, Di, _) in self.results.items():
+           vib.append(vi)
+           actual.append(Gi)
+           Bv.append(Bi)
+           Dv.append(Di)
 
         spl = interpolate.interp1d(vib, actual, kind='cubic')
         splB = interpolate.interp1d(vib, Bv, kind='cubic')
@@ -236,7 +224,7 @@ class Cse():
                 self.solve(en, rot)
 
         # sort in order of energy
-        self.results = sorted(self.results.items(), key=lambda t: t[1])
+        self.results = dict(sorted(self.results.items(), key=lambda t: t[1]))
 
     def diabatic2adiabatic(self):
         """ Convert diabatic interaction matrix to adiabatic (diagonal)

--- a/cse/johnson.py
+++ b/cse/johnson.py
@@ -208,7 +208,7 @@ def node_positions(WI, mn, mx):
     return inner, outer
 
 
-def matching_point(en, rot, V, R, μ, AM, eigenbound):
+def matching_point(en, rot, V, R, μ, AM):
     """ estimate matching point for inward and outward solutions position
     based on the determinant of the R-matrix.
 
@@ -258,8 +258,9 @@ def matching_point(en, rot, V, R, μ, AM, eigenbound):
         # outward node should suffice.
         vib = len(outer)  # node count
         if vib > 0:
-            mx = outer[-1] + mn + 5
-        #    mx = int((outer[-1] + inner[-1])*0.4) + mn
+            mx = int(outer.mean()) + mn
+            # mx = outer[-1] + mn + 5
+            # mx = int((outer[-1] + inner[-1])*0.4) + mn
 
     return mx, inner+mn, outer+mn
 
@@ -367,7 +368,7 @@ def amplitude(wf, R, edash, μ):
     return K, AI, B
 
 
-def solveCSE(Cse, en):
+def solveCSE(Cse, en, mx=None):
 
     rot = Cse.rot
     μ = Cse.μ
@@ -383,12 +384,12 @@ def solveCSE(Cse, en):
     openchann = edash > 0
     nopen = edash[openchann].size
 
-    mx, Cse.inner, Cse.outer = matching_point(en, rot, V, R, μ, AM,
-                                              Cse.eigenbound)
+    if mx is None:
+        mx, Cse.inner, Cse.outer = matching_point(en, rot, V, R, μ, AM)
 
     if mx < oo-5:
-        out = least_squares(eigen, (en, ),
-                            bounds=(en-Cse.eigenbound, en+Cse.eigenbound),
+        out = least_squares(eigen, (en, ), method='lm',
+                            # bounds=(en-Cse.eigenbound, en+Cse.eigenbound),
                             args=(rot, mx, V, R, μ, AM))
         en = float(out.x[0])
 

--- a/cse/johnson.py
+++ b/cse/johnson.py
@@ -389,7 +389,6 @@ def solveCSE(Cse, en, mx=None):
 
     if mx < oo-5:
         out = least_squares(eigen, (en, ), method='lm',
-                            # bounds=(en-Cse.eigenbound, en+Cse.eigenbound),
                             args=(rot, mx, V, R, μ, AM))
         en = float(out.x[0])
 

--- a/examples/output/example_O2_continuity.svg
+++ b/examples/output/example_O2_continuity.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-02-24T16:38:28.933304</dc:date>
+    <dc:date>2022-04-12T13:25:01.160423</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -38,40 +38,40 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="LineCollection_1">
-    <path clip-path="url(#pab4528f4fa)" d="M 79.674394 251.672133 
+    <path clip-path="url(#p504fc7b4cc)" d="M 79.674394 251.672133 
 L 79.674394 249.210185 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 85.325728 229.585072 
+    <path clip-path="url(#p504fc7b4cc)" d="M 85.325728 229.585072 
 L 85.325728 227.148945 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 90.776534 210.364836 
+    <path clip-path="url(#p504fc7b4cc)" d="M 90.776534 210.364836 
 L 90.776534 209.163431 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 96.018315 195.297262 
+    <path clip-path="url(#p504fc7b4cc)" d="M 96.018315 195.297262 
 L 96.018315 194.097279 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 101.041723 183.027416 
+    <path clip-path="url(#p504fc7b4cc)" d="M 101.041723 183.027416 
 L 101.041723 181.822111 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 105.825517 172.924229 
+    <path clip-path="url(#p504fc7b4cc)" d="M 105.825517 172.924229 
 L 105.825517 171.730606 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 110.351853 163.132147 
+    <path clip-path="url(#p504fc7b4cc)" d="M 110.351853 163.132147 
 L 110.351853 161.934167 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 114.610534 154.896072 
+    <path clip-path="url(#p504fc7b4cc)" d="M 114.610534 154.896072 
 L 114.610534 153.670237 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 118.566723 148.335355 
+    <path clip-path="url(#p504fc7b4cc)" d="M 118.566723 148.335355 
 L 118.566723 147.126787 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 122.211073 141.951462 
+    <path clip-path="url(#p504fc7b4cc)" d="M 122.211073 141.951462 
 L 122.211073 140.695724 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 125.512146 135.854358 
+    <path clip-path="url(#p504fc7b4cc)" d="M 125.512146 135.854358 
 L 125.512146 134.677927 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
-    <path clip-path="url(#pab4528f4fa)" d="M 128.44615 133.321528 
+    <path clip-path="url(#p504fc7b4cc)" d="M 128.44615 133.321528 
 L 128.44615 132.127905 
 " style="fill:none;stroke:#d62728;stroke-width:1.5;"/>
    </g>
@@ -87,21 +87,21 @@ C -1.789267 -1.03916 -2 -0.530406 -2 0
 C -2 0.530406 -1.789267 1.03916 -1.414214 1.414214 
 C -1.03916 1.789267 -0.530406 2 0 2 
 z
-" id="m92a4287235" style="stroke:#d62728;"/>
+" id="m3a87292741" style="stroke:#d62728;"/>
     </defs>
-    <g clip-path="url(#pab4528f4fa)">
-     <use style="fill:#ffffff;stroke:#d62728;" x="79.674394" xlink:href="#m92a4287235" y="250.378525"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="85.325728" xlink:href="#m92a4287235" y="228.305679"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="90.776534" xlink:href="#m92a4287235" y="209.749199"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="96.018315" xlink:href="#m92a4287235" y="194.682371"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="101.041723" xlink:href="#m92a4287235" y="182.409732"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="105.825517" xlink:href="#m92a4287235" y="172.312675"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="110.351853" xlink:href="#m92a4287235" y="162.518307"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="114.610534" xlink:href="#m92a4287235" y="154.267606"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="118.566723" xlink:href="#m92a4287235" y="147.715957"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="122.211073" xlink:href="#m92a4287235" y="141.307277"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="125.512146" xlink:href="#m92a4287235" y="135.251822"/>
-     <use style="fill:#ffffff;stroke:#d62728;" x="128.44615" xlink:href="#m92a4287235" y="132.709974"/>
+    <g clip-path="url(#p504fc7b4cc)">
+     <use style="fill:#ffffff;stroke:#d62728;" x="79.674394" xlink:href="#m3a87292741" y="250.378525"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="85.325728" xlink:href="#m3a87292741" y="228.305679"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="90.776534" xlink:href="#m3a87292741" y="209.749199"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="96.018315" xlink:href="#m3a87292741" y="194.682371"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="101.041723" xlink:href="#m3a87292741" y="182.409732"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="105.825517" xlink:href="#m3a87292741" y="172.312675"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="110.351853" xlink:href="#m3a87292741" y="162.518307"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="114.610534" xlink:href="#m3a87292741" y="154.267606"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="118.566723" xlink:href="#m3a87292741" y="147.715957"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="122.211073" xlink:href="#m3a87292741" y="141.307277"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="125.512146" xlink:href="#m3a87292741" y="135.251822"/>
+     <use style="fill:#ffffff;stroke:#d62728;" x="128.44615" xlink:href="#m3a87292741" y="132.709974"/>
     </g>
    </g>
    <g id="matplotlib.axis_1">
@@ -110,10 +110,10 @@ z
       <defs>
        <path d="M 0 0 
 L 0 3.5 
-" id="m876061395b" style="stroke:#000000;stroke-width:0.8;"/>
+" id="m00a43c205e" style="stroke:#000000;stroke-width:0.8;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="79.29288" xlink:href="#m876061395b" y="307.584"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="79.29288" xlink:href="#m00a43c205e" y="307.584"/>
       </g>
      </g>
      <g id="text_1">
@@ -178,7 +178,7 @@ z
     <g id="xtick_2">
      <g id="line2d_3">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="121.777728" xlink:href="#m876061395b" y="307.584"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="121.777728" xlink:href="#m00a43c205e" y="307.584"/>
       </g>
      </g>
      <g id="text_2">
@@ -195,7 +195,7 @@ z
     <g id="xtick_3">
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="164.262576" xlink:href="#m876061395b" y="307.584"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="164.262576" xlink:href="#m00a43c205e" y="307.584"/>
       </g>
      </g>
      <g id="text_3">
@@ -244,7 +244,7 @@ z
     <g id="xtick_4">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="206.747424" xlink:href="#m876061395b" y="307.584"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="206.747424" xlink:href="#m00a43c205e" y="307.584"/>
       </g>
      </g>
      <g id="text_4">
@@ -261,7 +261,7 @@ z
     <g id="xtick_5">
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="249.232272" xlink:href="#m876061395b" y="307.584"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="249.232272" xlink:href="#m00a43c205e" y="307.584"/>
       </g>
      </g>
      <g id="text_5">
@@ -290,7 +290,7 @@ z
     <g id="xtick_6">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="291.71712" xlink:href="#m876061395b" y="307.584"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="291.71712" xlink:href="#m00a43c205e" y="307.584"/>
       </g>
      </g>
      <g id="text_6">
@@ -307,7 +307,7 @@ z
     <g id="xtick_7">
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="334.201968" xlink:href="#m876061395b" y="307.584"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="334.201968" xlink:href="#m00a43c205e" y="307.584"/>
       </g>
      </g>
      <g id="text_7">
@@ -365,7 +365,7 @@ z
     <g id="xtick_8">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="376.686817" xlink:href="#m876061395b" y="307.584"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="376.686817" xlink:href="#m00a43c205e" y="307.584"/>
       </g>
      </g>
      <g id="text_8">
@@ -677,10 +677,10 @@ z
       <defs>
        <path d="M 0 0 
 L -3.5 0 
-" id="me54f064ea0" style="stroke:#000000;stroke-width:0.8;"/>
+" id="m4b8e349dc1" style="stroke:#000000;stroke-width:0.8;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#me54f064ea0" y="267.682897"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#m4b8e349dc1" y="267.682897"/>
       </g>
      </g>
      <g id="text_10">
@@ -742,7 +742,7 @@ z
     <g id="ytick_2">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#me54f064ea0" y="212.07269"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#m4b8e349dc1" y="212.07269"/>
       </g>
      </g>
      <g id="text_11">
@@ -759,7 +759,7 @@ z
     <g id="ytick_3">
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#me54f064ea0" y="156.462484"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#m4b8e349dc1" y="156.462484"/>
       </g>
      </g>
      <g id="text_12">
@@ -776,7 +776,7 @@ z
     <g id="ytick_4">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#me54f064ea0" y="100.852277"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#m4b8e349dc1" y="100.852277"/>
       </g>
      </g>
      <g id="text_13">
@@ -793,7 +793,7 @@ z
     <g id="ytick_5">
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#me54f064ea0" y="45.242071"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="57.6" xlink:href="#m4b8e349dc1" y="45.242071"/>
       </g>
      </g>
      <g id="text_14">
@@ -921,7 +921,7 @@ z
     </g>
    </g>
    <g id="line2d_15">
-    <path clip-path="url(#pab4528f4fa)" d="M 141.320758 116.709855 
+    <path clip-path="url(#p504fc7b4cc)" d="M 141.320758 116.709855 
 L 150.667425 107.093435 
 L 154.91591 103.197812 
 L 159.164394 99.603669 
@@ -1052,40 +1052,40 @@ L 375.83712 111.603236
 L 3 0 
 M 0 3 
 L 0 -3 
-" id="mde927c0446" style="stroke:#2ca02c;"/>
+" id="m216d2dd1c8" style="stroke:#2ca02c;"/>
     </defs>
-    <g clip-path="url(#pab4528f4fa)">
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="73.832727" xlink:href="#mde927c0446" y="280.253084"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="79.674394" xlink:href="#mde927c0446" y="249.952275"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="85.325728" xlink:href="#mde927c0446" y="227.594362"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="90.776534" xlink:href="#mde927c0446" y="209.721035"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="96.018315" xlink:href="#mde927c0446" y="194.915251"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="101.041723" xlink:href="#mde927c0446" y="182.398389"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="105.825517" xlink:href="#mde927c0446" y="171.766187"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="110.351853" xlink:href="#mde927c0446" y="162.66422"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="114.610534" xlink:href="#mde927c0446" y="154.833074"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="118.566723" xlink:href="#mde927c0446" y="148.212722"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="122.211073" xlink:href="#mde927c0446" y="142.476601"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="125.512146" xlink:href="#mde927c0446" y="137.703009"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="128.44615" xlink:href="#mde927c0446" y="133.641399"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="131.002038" xlink:href="#mde927c0446" y="130.271718"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="133.169615" xlink:href="#mde927c0446" y="127.534646"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="134.957378" xlink:href="#mde927c0446" y="125.317172"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="136.393365" xlink:href="#mde927c0446" y="123.587174"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="137.520064" xlink:href="#mde927c0446" y="122.295509"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="138.391003" xlink:href="#mde927c0446" y="121.177568"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="139.047819" xlink:href="#mde927c0446" y="119.996697"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="139.510054" xlink:href="#mde927c0446" y="118.61015"/>
-     <use style="fill:#2ca02c;stroke:#2ca02c;" x="139.797251" xlink:href="#mde927c0446" y="125.632161"/>
+    <g clip-path="url(#p504fc7b4cc)">
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="73.832727" xlink:href="#m216d2dd1c8" y="280.253084"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="79.674394" xlink:href="#m216d2dd1c8" y="249.952275"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="85.325728" xlink:href="#m216d2dd1c8" y="227.594362"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="90.776534" xlink:href="#m216d2dd1c8" y="209.721035"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="96.018315" xlink:href="#m216d2dd1c8" y="194.915251"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="101.041723" xlink:href="#m216d2dd1c8" y="182.398389"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="105.825517" xlink:href="#m216d2dd1c8" y="171.766187"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="110.351853" xlink:href="#m216d2dd1c8" y="162.66422"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="114.610534" xlink:href="#m216d2dd1c8" y="154.833074"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="118.566723" xlink:href="#m216d2dd1c8" y="148.212722"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="122.211073" xlink:href="#m216d2dd1c8" y="142.476601"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="125.512146" xlink:href="#m216d2dd1c8" y="137.703009"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="128.44615" xlink:href="#m216d2dd1c8" y="133.641399"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="131.002038" xlink:href="#m216d2dd1c8" y="130.271718"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="133.169615" xlink:href="#m216d2dd1c8" y="127.534646"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="134.957378" xlink:href="#m216d2dd1c8" y="125.317172"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="136.393365" xlink:href="#m216d2dd1c8" y="123.587174"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="137.520064" xlink:href="#m216d2dd1c8" y="122.295509"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="138.391003" xlink:href="#m216d2dd1c8" y="121.177568"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="139.047819" xlink:href="#m216d2dd1c8" y="119.996697"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="139.510054" xlink:href="#m216d2dd1c8" y="118.610149"/>
+     <use style="fill:#2ca02c;stroke:#2ca02c;" x="139.797251" xlink:href="#m216d2dd1c8" y="125.632161"/>
     </g>
    </g>
    <g id="line2d_17">
-    <path clip-path="url(#pab4528f4fa)" d="M 139.928955 295.488 
+    <path clip-path="url(#p504fc7b4cc)" d="M 139.928955 295.488 
 L 139.928955 100.852277 
 " style="fill:none;stroke:#000000;stroke-dasharray:3.7,1.6;stroke-dashoffset:0;"/>
    </g>
    <g id="line2d_18">
-    <path clip-path="url(#pab4528f4fa)" d="M 398.487273 161.731607 
+    <path clip-path="url(#p504fc7b4cc)" d="M 398.487273 161.731607 
 L 397.836317 141.603386 
 L 397.186498 140.718006 
 L 396.537815 136.150506 
@@ -1866,7 +1866,7 @@ z
     <g id="line2d_21"/>
     <g id="line2d_22">
      <g>
-      <use style="fill:#2ca02c;stroke:#2ca02c;" x="194.46" xlink:href="#mde927c0446" y="263.62775"/>
+      <use style="fill:#2ca02c;stroke:#2ca02c;" x="194.46" xlink:href="#m216d2dd1c8" y="263.62775"/>
      </g>
     </g>
     <g id="text_20">
@@ -2091,7 +2091,7 @@ L 194.46 288.004312
     <g id="line2d_25"/>
     <g id="line2d_26">
      <g>
-      <use style="fill:#ffffff;stroke:#d62728;" x="194.46" xlink:href="#m92a4287235" y="293.004312"/>
+      <use style="fill:#ffffff;stroke:#d62728;" x="194.46" xlink:href="#m3a87292741" y="293.004312"/>
      </g>
     </g>
     <g id="text_22">
@@ -2143,7 +2143,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pab4528f4fa">
+  <clipPath id="p504fc7b4cc">
    <rect height="266.112" width="357.12" x="57.6" y="41.472"/>
   </clipPath>
  </defs>


### PR DESCRIPTION
The selection of matching point, mx, is problematic for coupled (all) bound states, and an incorrect value causes a discontinuity in the wavefunctions (from the miss-match of inward, and outward solutions). A semi-empirical approach is, at the moment, the only reliable method, specifying mx, and examining the wavefunctions near the matching point. This PR provides the ability to specify mx in `solve()` and the class instances.

Python3 dicts are ordered, removed OrderedDict. Using 'lm' Levenberg-Marquardt method, which appears more accurate, but has no handling of bounds. Removed eigenbound parameter. Made vibrational quantum number an integer type.'
